### PR TITLE
updates to calibeovsa

### DIFF
--- a/tasks/calibeovsa.xml
+++ b/tasks/calibeovsa.xml
@@ -40,9 +40,11 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
             'refamp': reference amplitude calibration (not used anymore)
             'phacal': daily phase calibration
             'fluxcal': flux calibration based on total-power measurements
-             default value: ['refpha','phacal','fluxcal']
-             *** note if fluxcal is already done to the UDB/IDB miriad files, it should not be performed again ***
+             default value: ['refpha','phacal']
+             *** note fluxcal is already implemented in udb_corr when doing importeovsa, should not be used anymore ****
              *** pipeline only uses ['refpha','phacal']
+
+        caltbdir -- string. Place to hold calibration tables. Default is current directory. Pipeline should use /data1/eovsa/caltable
 
         interp -- string. How interpolation is done for phacal? 'nearest' or 'linear'
 
@@ -65,9 +67,13 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
 
         stokes -- string. Which stokes for the quicklook image. CASA syntax. Default 'XX'
 
+        dosplit -- boolean. Split the corrected data column?
+
+        outputvis -- string. Output visibility file after split 
+
         doconcat -- boolean. If more than one visibility dataset provided, concatenate all into one or make separate outputs if True
 
-        msoutdir -- string. Directory to place the concatenated dataset
+        concatvis -- string. Output visibility file after concatenation
 
         keep_orig_ms -- boolean. Default True. Inherited from suncasa.eovsa.concateovsa.
                 Keep the original seperated ms datasets after concatenation?
@@ -84,7 +90,12 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
         <param type="any" name="caltype">
             <description>Types of calibrations to perform</description>
             <any type="variant" limittypes="string stringArray"/>
-            <value type="stringArray">"refpha","phacal","fluxcal"</value>
+            <value type="stringArray">"refpha","phacal"</value>
+        </param>
+
+        <param type="string" name="caltbdir">
+            <description>Directory to place calibration tables.</description>
+            <value type="string"></value>
         </param>
 
         <param type="string" name="interp">
@@ -109,7 +120,7 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
 
         <param type="bool" name="doimage">
             <description>If True, produce a quicklook image after calibration (sunpy must be installed).</description>
-            <value>True</value>
+            <value>False</value>
         </param>
 
         <param type="string" name="imagedir" subparam="true">
@@ -137,23 +148,29 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
             <value type="string">XX</value>
         </param>
 
-        <param type="bool" name="doconcat">
-            <description>If more than one visibility dataset provided, concatenate all into one or make separate outputs if True.</description>
+        <param type="bool" name="dosplit">
+            <description>If True, plit the corrected data column as output visibility file.</description>
             <value>False</value>
         </param>
 
-        <param type="string" name="msoutdir" subparam="true">
-            <description>Path of output concatenated ms. Default is current directory.</description>
-            <value type="string">.</value>
+        <param type="any" name="outputvis" subparam="true">
+	    <any type="variant" limittypes="string stringArray"/>
+            <description>Name of output visibility file. Default is the name of the first vis file ended with ".corrected.ms".</description>
+            <value type="string"></value>
+        </param>
+
+        <param type="bool" name="doconcat">
+            <description>If True, and if more than one visibility dataset provided, concatenate all into one visibility.</description>
+            <value>False</value>
         </param>
 
         <param type="string" name="concatvis" subparam="true">
-            <description>Name of output visibility file. Default is the name of the first vis file appended by a suffix: _concat.</description>
+            <description>Name of output visibility file. Default is the name of the first + last vis file ended with ".corrected.ms".</description>
             <value type="string"></value>
         </param>
 
         <param type="bool" name="keep_orig_ms" subparam="true">
-            <description>Keep the original seperated ms datasets after concatenation?</description>
+            <description>Keep the original seperated ms datasets after split?</description>
             <value>True</value>
         </param>
 
@@ -175,10 +192,17 @@ file:///opt/casa/code/xmlcasa/xml/casa.xsd">
                     <default param="stokes"><value type="string">XX</value></default>
                 </equals>
             </when>
+            <when param="dosplit">
+                <equals type="bool" value="False"/>
+                <equals type="bool" value="True">
+                    <default param="outputvis"><value type="string"></value></default>
+                    <default param="keep_orig_ms"><value type="bool">True</value></default>
+                </equals>
+            </when>
             <when param="doconcat">
                 <equals type="bool" value="False"/>
                 <equals type="bool" value="True">
-                    <default param="msoutdir"><value type="string">.</value></default>
+                    <default param="concatvis"><value type="string"></value></default>
                     <default param="keep_orig_ms"><value type="bool">True</value></default>
                 </equals>
             </when>

--- a/tasks/task_calibeovsa.py
+++ b/tasks/task_calibeovsa.py
@@ -10,6 +10,7 @@ from taskinit import casalog, tb, ms
 from gencal_cli import gencal_cli as gencal
 from clearcal_cli import clearcal_cli as clearcal
 from applycal_cli import applycal_cli as applycal
+from flagdata_cli import flagdata_cli as flagdata
 from clean_cli import clean_cli as clean
 from split_cli import split_cli as split
 from bandpass_cli import bandpass_cli as bandpass
@@ -20,17 +21,10 @@ from eovsapy import dbutil as db
 from eovsapy import pipeline_cal as pc
 from importeovsa_cli import importeovsa_cli as importeovsa
 
-# check if the calibration table directory is defined
-caltbdir = os.getenv('EOVSACAL')
-if not caltbdir:
-    print('Task calibeovsa')
-    caltbdir = '/data1/eovsa/caltable/'
-    print('Environmental variable for EOVSA calibration table path not defined')
-    print('Use default path on pipeline ' + caltbdir)
 
 
-def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, flagant='13~15', doimage=False, imagedir=None, antenna=None,
-               timerange=None, spw=None, stokes=None, doconcat=False, msoutdir=None, concatvis=None, keep_orig_ms=True):
+def calibeovsa(vis=None, caltype=None, caltbdir=None, interp=None, docalib=True, doflag=True, flagant='13~15', doimage=False, imagedir=None, antenna=None,
+               timerange=None, spw=None, stokes=None, dosplit=False, outputvis=None, doconcat=False, concatvis=None, keep_orig_ms=True):
     '''
 
     :param vis: EOVSA visibility dataset(s) to be calibrated 
@@ -51,11 +45,19 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
         if f[-1] == '/':
             vis[idx] = f[:-1]
 
+    # check if the calibration table directory is defined
+    # pipeline should always use "caltbdir = /data1/eovsa/caltable/"
+    if not caltbdir:
+        print('Task calibeovsa')
+        print('Path for generating calibration tables not defined')
+        print('Use current path ' + caltbdir)
+        caltbdir = './'
+
     for msfile in vis:
         casalog.origin('calibeovsa')
         if not caltype:
             casalog.post("Caltype not provided. Perform reference phase calibration and daily phase calibration.")
-            caltype = ['refpha', 'phacal', 'fluxcal']  ## use this line after the phacal is applied  # caltype = ['refcal']
+            caltype = ['refpha', 'phacal']  ## use this line after the phacal is applied  # caltype = ['refcal']
         if not os.path.exists(msfile):
             casalog.post("Input visibility does not exist. Aborting...")
             continue
@@ -71,7 +73,7 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
         nspw = tb.nrows()
         bdname = tb.getcol('NAME')
         bd_nchan = tb.getcol('NUM_CHAN')
-        bd = [int(b[4:]) - 1 for b in bdname]  # band index from 0 to 33
+        bd = [int(b[4:]) - 1 for b in bdname]
         # nchans = tb.getcol('NUM_CHAN')
         # reffreqs = tb.getcol('REF_FREQUENCY')
         # cenfreqs = np.zeros((nspw))
@@ -82,6 +84,7 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
         antlist = [str(ll) for ll in range(len(antname) - 1)]
         antennas = ','.join(antlist)
         tb.close()
+
 
         # get time stamp, use the beginning of the file
         tb.open(msfile + '/OBSERVATION')
@@ -137,15 +140,17 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
 
             para_pha = []
             para_amp = []
-            calpha = np.zeros((nspw, 15, 2))
-            calamp = np.zeros((nspw, 15, 2))
+            calpha = np.zeros((nspw, nant-1, 2))
+            calamp = np.zeros((nspw, nant-1, 2))
             for s in range(nspw):
-                for n in range(15):
+                for n in range(nant-1):
                     for p in range(2):
                         calpha[s, n, p] = pha[n, p, bd[s]]
                         calamp[s, n, p] = amp[n, p, bd[s]]
                         para_pha.append(np.degrees(pha[n, p, bd[s]]))
                         para_amp.append(amp[n, p, bd[s]])
+
+
 
         if 'fluxcal' in caltype:
             calfac = pc.get_calfac(Time(t_mid.iso.split(' ')[0] + 'T23:59:59'))
@@ -195,22 +200,46 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
             caltb_pha = dirname + t_ref.isot[:-4].replace(':', '').replace('-', '') + '.refpha'
             if not os.path.exists(caltb_pha):
                 gencal(vis=msfile, caltable=caltb_pha, caltype='ph', antenna=antennas, pol='X,Y', spw='0~' + str(nspw - 1), parameter=para_pha)
+                tb.open(caltb_pha, nomodify=False)
+                phaflag_ = refcal['flag'][:,:,np.array(bd)]
+                phaflag_new = np.full((nant, 2, nspw), True,dtype=np.bool)
+                phaflag_new[:-1,...] = phaflag_
+                phaflag_new = np.moveaxis(phaflag_new, 0, 2).reshape(2, 1, 800)
+                tb.putcol('FLAG', phaflag_new)
+                tb.close()
+
+                # tb.open(caltb_pha, nomodify=False)
+                # phaparam = np.angle(tb.getcol('CPARAM'),deg=True)
+                # phaparam_ = np.degrees(refcal['pha'][:,:,np.array(bd)])
+                # phaparam2 = np.zeros((nant, 2, nspw))
+                # phaparam2[:-1,...] = phaparam_
+                # # phaparam2 = phaparam2.swapaxes(0,1).reshape(2,1,800)
+                # phaparam2 = np.moveaxis(phaparam2,0,2).reshape(2,1,800)
+                # tb.close()
+
             gaintables.append(caltb_pha)
         if ('refamp' in caltype) or ('refcal' in caltype):
             # caltb_amp = os.path.basename(vis).replace('.ms', '.refamp')
             caltb_amp = dirname + t_ref.isot[:-4].replace(':', '').replace('-', '') + '.refamp'
             if not os.path.exists(caltb_amp):
                 gencal(vis=msfile, caltable=caltb_amp, caltype='amp', antenna=antennas, pol='X,Y', spw='0~' + str(nspw - 1), parameter=para_amp)
+                tb.open(caltb_amp, nomodify=False)
+                ampflag_ = refcal['flag'][:,:,np.array(bd)]
+                ampflag_new = np.full((nant, 2, nspw), True,dtype=np.bool)
+                ampflag_new[:-1,...] = ampflag_
+                ampflag_new = np.moveaxis(ampflag_new, 0, 2).reshape(2, 1, 800)
+                tb.putcol('FLAG', ampflag_new)
+                tb.close()
             gaintables.append(caltb_amp)
 
         # calibration for the change of delay center between refcal time and beginning of scan -- hopefully none!
         xml, buf = ch.read_calX(4, t=[t_ref, btime], verbose=False)
         if buf:
             dly_t2 = Time(stf.extract(buf[0], xml['Timestamp']), format='lv')
-            dlycen_ns2 = stf.extract(buf[0], xml['Delaycen_ns'])[:15]
+            dlycen_ns2 = stf.extract(buf[0], xml['Delaycen_ns'])[:nant-1]
             xml, buf = ch.read_calX(4, t=t_ref)
             dly_t1 = Time(stf.extract(buf, xml['Timestamp']), format='lv')
-            dlycen_ns1 = stf.extract(buf, xml['Delaycen_ns'])[:15]
+            dlycen_ns1 = stf.extract(buf, xml['Delaycen_ns'])[:nant-1]
             dlycen_ns_diff = dlycen_ns2 - dlycen_ns1
             for n in range(2):
                 dlycen_ns_diff[:, n] -= dlycen_ns_diff[0, n]
@@ -365,25 +394,39 @@ def calibeovsa(vis=None, caltype=None, interp=None, docalib=True, doflag=True, f
                 eomap.plot_settings['cmap'] = plt.get_cmap('jet')
                 eomap.plot()
                 eomap.draw_limb()
-                eomap.draw_grid()
+                # the next line would cause trouble in higher versions of SunPy, as it requires WCS
+                # eomap.draw_grid()
 
             plt.show()
 
+    if dosplit:
+        if not doconcat:
+            if not outputvis:
+                outputvis = [vis[n].split('.')[0] + '.corrected.ms' for n in range(len(vis))]
+            for n in range(len(vis)):
+                split(vis=vis[n], outputvis=outputvis[n], datacolumn='corrected')
+                if not keep_orig_ms:
+                    os.system('rm -rf {}'.format(vis[n]))
+    else:
+        outputvis = vis
+
     if doconcat:
+        #doconcat imply dosplit
         from suncasa.tasks import concateovsa_cli as ce
         # from suncasa.eovsa import concateovsa as ce
-        if msoutdir is None:
-            msoutdir = './'
         if not concatvis:
-            concatvis = os.path.basename(vis[0])
-            concatvis = msoutdir + '/' + concatvis.split('.')[0] + '_concat.ms'
+            if len(vis) == 1:
+                vis0 = os.path.basename(vis[0])
+                concatvis = vis0.split('.')[0] + '.corrected.ms'
+            if len(vis) > 1:
+                visb = os.path.basename(vis[0])
+                vise = os.path.basename(vis[-1])
+                concatvis = visb.split('.')[0]  + '-' + vise.split('.')[0][3:] + '.corrected.ms'
         else:
-            concatvis = os.path.join(msoutdir, concatvis)
-        if len(vis) > 1:
-            ce.concateovsa(vis, concatvis, datacolumn='corrected', keep_orig_ms=keep_orig_ms, cols2rm="model,corrected")
-            return [concatvis]
-        else:
-            split(vis=vis[0], outputvis=concatvis, datacolumn='corrected')
-            return [concatvis]
+            if len(vis) == 1:
+                split(vis=vis0, outputvis=concatvis, datacolumn='corrected')
+            if len(vis) > 1:
+                ce.concateovsa(vis, concatvis, datacolumn='corrected', keep_orig_ms=keep_orig_ms, cols2rm="model,corrected")
+        return [concatvis]
     else:
-        return vis
+        return outputvis


### PR DESCRIPTION
- added a new keyword "caltbdir" to place the calibration tables. If not defined, use current directory. pipeline should always use "caltbdir='/data1/eovsa/caltable/' to avoid creating these tables repeatedly. This would also solve the permission issue when running calibeovsa with a different account (not "user").
- added a new keyword "dosplit". If True, split the corrected datacolumn as defined by outputvis
- changed the sub-keywords under "doconcat".
- changed the default caltype to ["refcal", "phacal"]. "fluxcal" is obsolete now with udb_corr in place.
- changed the default value of doimage=True to False
- fixed an error when doimage=True. eomap.draw_grid() fails with the newer version of sunpy. I just removed that line.