### PR TITLE
Fix bugs in dspec, qlookplot, and mstools

### DIFF
--- a/suncasa/utils/mstools.py
+++ b/suncasa/utils/mstools.py
@@ -46,43 +46,30 @@ def get_bandinfo(msfile, spw=None, returnbdinfo=False):
     bdwds = np.array(bdwds) / 1e9
     chanwds = np.array(chanwds) / 1e9
     nchans = np.array(nchans)
-    ms.close()
     cfreqs = reffreqs + bdwds / 2.0 - chanwds / 2.0
     bdinfo = {'bounds_all': np.hstack((reffreqs, reffreqs[-1] + bdwds[-1])), 'cfreqs_all': cfreqs,
               'bounds_all_lo': reffreqs, 'bounds_all_hi': reffreqs + bdwds}
-    if spw is not None:
+    if spw:
         freqbounds_lo_spw = []
         freqbounds_hi_spw = []
         cfreqs_spw = []
         for sp in spw:
-            if ':' in sp:
-                sp_, chn = sp.split(':')
-                sp_ = int(sp_)
-                if '~' in chn:
-                    chns = chn.split('~')
-                    freqbound_lo = reffreqs[sp_] + chanwds[sp_] * int(chns[0])
-                    freqbound_hi = reffreqs[sp_] + chanwds[sp_] * (int(chns[1]) + 1)
-                else:
-                    ch = max(0, min(int(chn), nchans[sp_] - 1))
-                    freqbound_lo = reffreqs[sp_] + chanwds[sp_] * ch
-                    freqbound_hi = reffreqs[sp_] + chanwds[sp_] * (ch+1)
-                cfreq = (freqbound_lo + freqbound_hi) / 2.0
-            else:
-                if '~' in sp:
-                    sps = sp.split('~')
-                    cfreq = np.nanmean([cfreqs[max(0, min(int(s), nspw - 1))] for s in sps])
-                    s1 = max(0, min(int(sps[0]), nspw - 1))
-                    s2 = max(0, min(int(sps[1]) + 1, nspw - 1))
-                    freqbound_lo = bdinfo['bounds_all'][s1]
-                    freqbound_hi = bdinfo['bounds_all'][s2]
-                else:
-                    s = max(0, min(int(sp), nspw - 1))
-                    cfreq = cfreqs[s]
-                    freqbound_lo = bdinfo['bounds_all'][s]
-                    # freqbound_hi = freqbounds['bounds_all'][max(0, min(int(sp) + 1, nspw - 1))]
-                    freqbound_hi = bdinfo['bounds_all'][s] + bdwds[s]
-            freqbounds_lo_spw.append(freqbound_lo)
-            freqbounds_hi_spw.append(freqbound_hi)
+            try:
+                staql = {'spw': sp}
+                ms.msselect(staql, onlyparse=True)
+                ndx = ms.msselectedindices()
+                chan_sel = ndx['channel']
+                bspw = chan_sel[0, 0]
+                bchan = chan_sel[0, 1]
+                espw = chan_sel[-1, 0]
+                echan = chan_sel[-1, 2]
+                bfreq = spwInfo[str(bspw)]['Chan1Freq'] + spwInfo[str(bspw)]['ChanWidth'] * bchan
+                efreq = spwInfo[str(espw)]['Chan1Freq'] + spwInfo[str(espw)]['ChanWidth'] * echan
+                cfreq = (bfreq + efreq) / 2.
+            except ValueError:
+                print("Parsing spw failed. Aborting...")
+            freqbounds_lo_spw.append(bfreq)
+            freqbounds_hi_spw.append(efreq)
             cfreqs_spw.append(cfreq)
         cfreqs = np.array(cfreqs_spw)
         freqbounds_lo = np.array(freqbounds_lo_spw)
@@ -90,6 +77,8 @@ def get_bandinfo(msfile, spw=None, returnbdinfo=False):
         bdinfo['bounds_lo'] = freqbounds_lo
         bdinfo['bounds_hi'] = freqbounds_hi
         bdinfo['cfreqs'] = cfreqs
+
+    ms.close()
     if returnbdinfo:
         return bdinfo
     else:

--- a/suncasa/utils/mstools.py
+++ b/suncasa/utils/mstools.py
@@ -63,8 +63,8 @@ def get_bandinfo(msfile, spw=None, returnbdinfo=False):
                 bchan = chan_sel[0, 1]
                 espw = chan_sel[-1, 0]
                 echan = chan_sel[-1, 2]
-                bfreq = spwInfo[str(bspw)]['Chan1Freq'] + spwInfo[str(bspw)]['ChanWidth'] * bchan
-                efreq = spwInfo[str(espw)]['Chan1Freq'] + spwInfo[str(espw)]['ChanWidth'] * echan
+                bfreq = (spwInfo[str(bspw)]['Chan1Freq'] + spwInfo[str(bspw)]['ChanWidth'] * bchan) / 1e9
+                efreq = (spwInfo[str(espw)]['Chan1Freq'] + spwInfo[str(espw)]['ChanWidth'] * echan) / 1e9
                 cfreq = (bfreq + efreq) / 2.
             except ValueError:
                 print("Parsing spw {} failed. Aborting...".format(sp))

--- a/suncasa/utils/mstools.py
+++ b/suncasa/utils/mstools.py
@@ -67,7 +67,8 @@ def get_bandinfo(msfile, spw=None, returnbdinfo=False):
                 efreq = spwInfo[str(espw)]['Chan1Freq'] + spwInfo[str(espw)]['ChanWidth'] * echan
                 cfreq = (bfreq + efreq) / 2.
             except ValueError:
-                print("Parsing spw failed. Aborting...")
+                print("Parsing spw {} failed. Aborting...".format(sp))
+                continue
             freqbounds_lo_spw.append(bfreq)
             freqbounds_hi_spw.append(efreq)
             cfreqs_spw.append(cfreq)

--- a/suncasa/utils/qlookplot.py
+++ b/suncasa/utils/qlookplot.py
@@ -1653,26 +1653,6 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
             spwselec = '0~' + str(nspwall - 1)
             spw = [spwselec]
     else:
-        if 'GHz' in spw:
-            start_spw=None
-            end_spw=None
-            temp=spw.split('GHz')[0].split('~')
-            s1=int(temp[0])
-            s2=int(temp[1])
-            for i in range(nspwall):
-                if spwInfo[str(i)]['RefFreq']>s1*1e9:
-                    start_spw=str(i)
-                    break
-            if start_spw==None:
-                ms.close()
-                return -1
-            for i in range(nspwall):
-                if spwInfo[str(i)]['RefFreq']>s2*1e9:
-                    end_spw=str(i)
-                    break
-            if end_spw==None:
-                end_spw=str(nspwall-1)
-            spw=start_spw+'~'+end_spw
         if type(spw) is list:
             spwselec = ';'.join(spw)
         else:
@@ -1695,6 +1675,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
     else:
         icmap = plt.get_cmap(icmap)
 
+    print('spw is', spw)
     bdinfo = mstools.get_bandinfo(vis, spw=spw, returnbdinfo=True)
     # print(freqbounds)
     cfreqs = bdinfo['cfreqs']
@@ -2056,13 +2037,15 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                 if nspws > 1:
                     imagefiles, fitsfiles = [], []
                     if restoringbeam == ['']:
-                        restoringbms = [''] * nspws
+                        if observatory == 'EOVSA':
+                            restoringbms = mstools.get_bmsize(cfreqs, refbmsize=60., reffreq=1., minbmsize=4.0)
+                        else:
+                            restoringbms = [''] * nspws
                     else:
                         try:
-                            sbeam = float(restoringbeam[0].replace('arcsec', ''))
-                        except:
-                            sbeam = 35.
-                        restoringbms = mstools.get_bmsize(cfreqs, refbmsize=sbeam, reffreq=1.6, minbmsize=4.0)
+                            restoringbms = [float(b.replace('arcsec', '')) for b in restoringbeam]
+                        except ValueError:
+                            print('Error in reading the provided restoring beam.')
                     sto = stokes.replace(',', '')
                     print('Original phasecenter: ' + str(ra0) + str(dec0))
                     print('use phasecenter: ' + phasecenter)
@@ -2131,6 +2114,18 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                         "If the provided spw is not equally spaced, the frequency information of the fits file {} that combining {} could be a wrong. Use it with caution!".format(
                             outfits, ','.join(fitsfiles)))
                 else:
+                    # single image
+                    if restoringbeam == ['']:
+                        if observatory == 'EOVSA':
+                            # Don't use CASA's default. Trying my best to get a good estimate of the restoring beam
+                            restoringbms = mstools.get_bmsize(cfreqs_all, refbmsize=60., reffreq=1., minbmsize=4.0)
+                            ms.open(vis)
+                            staql = {'spw': ';'.join(spw)}
+                            ms.msselect(staql, onlyparse=True)
+                            spwidx = ms.msselectedindices()['spw']
+                            ms.close()
+                            bm = str(np.mean(restoringbms[spwidx]))+'arcsec'
+
                     imagename = os.path.join(workdir, visname + '.outim')
                     junks = ['.flux', '.model', '.psf', '.residual', '.mask', '.pb', '.sumwt', '.image', '.image.pbcor']
                     for junk in junks:
@@ -2140,8 +2135,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                     print('do clean for ' + timerange + ' in spw ' + ';'.join(spw) + ' stokes ' + sto)
                     print('Original phasecenter: ' + str(ra0) + str(dec0))
                     print('use phasecenter: ' + phasecenter)
-                    # if verbose:
-                    #     print('use beamsize {}'.format(restoringbeam))
+                    print('use restoringbeam {}'.format(restoringbeam))
 
                     tclean(vis=vis,
                            imagename=imagename,
@@ -2158,7 +2152,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                            imsize=imsize,
                            cell=cell,
                            datacolumn=datacolumn,
-                           restoringbeam=restoringbeam,
+                           restoringbeam=bm,
                            weighting=weighting,
                            robust=robust,
                            phasecenter=phasecenter)

--- a/suncasa/utils/qlookplot.py
+++ b/suncasa/utils/qlookplot.py
@@ -2038,7 +2038,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                     imagefiles, fitsfiles = [], []
                     if restoringbeam == ['']:
                         if observatory == 'EOVSA':
-                            restoringbms = mstools.get_bmsize(cfreqs, refbmsize=60., reffreq=1., minbmsize=4.0)
+                            restoringbms = mstools.get_bmsize(cfreqs, refbmsize=70., reffreq=1., minbmsize=4.0)
                         else:
                             restoringbms = [''] * nspws
                     else:
@@ -2118,13 +2118,8 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                     if restoringbeam == ['']:
                         if observatory == 'EOVSA':
                             # Don't use CASA's default. Trying my best to get a good estimate of the restoring beam
-                            restoringbms = mstools.get_bmsize(cfreqs_all, refbmsize=60., reffreq=1., minbmsize=4.0)
-                            ms.open(vis)
-                            staql = {'spw': ';'.join(spw)}
-                            ms.msselect(staql, onlyparse=True)
-                            spwidx = ms.msselectedindices()['spw']
-                            ms.close()
-                            bm = str(np.mean(restoringbms[spwidx]))+'arcsec'
+                            restoringbms = mstools.get_bmsize(cfreqs, refbmsize=70., reffreq=1., minbmsize=4.0)
+                            restoringbeam = str(np.mean(restoringbms[0]))+'arcsec'
 
                     imagename = os.path.join(workdir, visname + '.outim')
                     junks = ['.flux', '.model', '.psf', '.residual', '.mask', '.pb', '.sumwt', '.image', '.image.pbcor']
@@ -2152,7 +2147,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                            imsize=imsize,
                            cell=cell,
                            datacolumn=datacolumn,
-                           restoringbeam=bm,
+                           restoringbeam=restoringbeam,
                            weighting=weighting,
                            robust=robust,
                            phasecenter=phasecenter)


### PR DESCRIPTION
dspec.tofits() has the frequency axis multiplied by an extra 1e9. Removed.
qlookplot should use circular restoring beam when working on EOVSA data if spw = ['']. Updated to include this. 
mstools was not versatile enough to recognize spw syntax (e.g., '5GHz~10GHz'). Use the staql method to do this.