### PR TITLE
Fix fits unclosed warning in dspec/resources/eovsa.py

### DIFF
--- a/suncasa/dspec/sources/eovsa.py
+++ b/suncasa/dspec/sources/eovsa.py
@@ -105,4 +105,5 @@ def get_dspec(filename, doplot=False, vmax=None, vmin=None, norm=None, cmap=None
         ax.format_coord = format_coord
         fig.tight_layout()
         plt.show()
+    hdulist.close()
     return {'spectrogram': spec, 'spectrum_axis': fghz, 'time_axis': tmjd}


### PR DESCRIPTION
The file is unclosed when reading a fits file with dspec/resources/eovsa.py. It does not release memory and is taking up resources. Added a line to close it. 