### PR TITLE
Fix the issue that the output time range for FITS files does not matc…

### DIFF
--- a/suncasa/eovsa/eovsa_flare_calib.py
+++ b/suncasa/eovsa/eovsa_flare_calib.py
@@ -44,10 +44,25 @@ def import_calib_idb(trange, workdir=None, ncpu=1, timebin='0s', width=1):
     idxs, = np.where(info['SOURCEID'] == '')
     for k, v in info.items():
         info[k] = info[k][~(info[k] == '')]
-    sidx = np.where(
-        np.logical_and(info['SOURCEID'] == 'Sun', info['PROJECTID'] == 'NormalObserving') & np.logical_and(
-            info['ST_TS'].astype(np.float_) >= trange[0].lv,
-            info['ST_TS'].astype(np.float_) <= trange[1].lv))
+    # sidx = np.where(
+    #     np.logical_and(info['SOURCEID'] == 'Sun', info['PROJECTID'] == 'NormalObserving') & np.logical_and(
+    #         info['ST_TS'].astype(np.float_) >= trange[0].lv,
+    #         info['ST_TS'].astype(np.float_) <= trange[1].lv))
+    
+    term1 = np.logical_and(info['SOURCEID'] == 'Sun', info['PROJECTID'] == 'NormalObserving')
+    st_ts_float = info['ST_TS'].astype(np.float_)
+
+    term2_ind = []
+    term3_ind = []
+
+    for i in range(len(st_ts_float) - 1):
+        if term1[i] and (st_ts_float[i] <= trange[0].lv <= st_ts_float[i + 1]):
+            term2_ind.append(i)
+        if term1[i] and (st_ts_float[i] <= trange[1].lv <= st_ts_float[i + 1]):
+            term3_ind.append(i)
+
+    sidx = list(range(term2_ind[0], term3_ind[0] + 1))
+
     filelist = info['FILE'][sidx]
     # filelist = filelist[np.array([0, 2, 3, 4, 5, 6, 7, 8])]
     # filelist = filelist[np.array([0, 2])]

--- a/suncasa/eovsa/eovsa_flare_pipeline.py
+++ b/suncasa/eovsa/eovsa_flare_pipeline.py
@@ -1702,21 +1702,24 @@ class FlareSelfCalib():
             if self.imaging_start is None:
                 self.imaging_start_mjd = self.flare_peak_mjd - self.total_duration / 2
             else:
-                self.imaging_start_mjd=Time(self.imaging_start).mjd*86400 # in mjd seconds
+                self.imaging_start_mjd = Time(self.imaging_start).mjd*86400 # in mjd seconds
                 
             if self.imaging_start_mjd < self.ms_startmjd:
                 self.logf.write("Start time given for imaging is before the start time of MS. Resetting to first time of MS.")
-                self.imaging_start_mjd=self.ms_startmjd
+                self.imaging_start_mjd = self.ms_startmjd
             
             if self.imaging_end is None:
-                self.imaging_end_mjd = self.flare_peak_mjd - self.total_duration / 2 
+                self.imaging_end_mjd = self.flare_peak_mjd + self.total_duration / 2 
             else:
-                self.imaging_end_mjd=Time(self.imaging_end).mjd*86400 ### in mjd seconds
+                self.imaging_end_mjd = Time(self.imaging_end).mjd*86400 ### in mjd seconds
             
+            if self.imaging_end_mjd < self.ms_startmjd:
+                self.logf.write("End time given for imaging is before the start time of MS. Resetting to last time of MS.")
+                self.imaging_end_mjd = self.ms_endmjd
+
             if self.imaging_end_mjd > self.ms_endmjd:
                 self.logf.write("End time given for imaging is after the end time of MS. Resetting to last time of MS.")
-                self.imaging_end_mjd=self.ms_endmjd
-            
+                self.imaging_end_mjd = self.ms_endmjd
             
             imaging_start_time=Time(self.imaging_start_mjd/86400,format='mjd').datetime.strftime(
                     "%Y/%m/%d/%H:%M:%S")   
@@ -1725,7 +1728,6 @@ class FlareSelfCalib():
                     "%Y/%m/%d/%H:%M:%S")
                     
             
-
             time_str = imaging_start_time + "~" + imaging_end_time
 
             specfile = msname[:-3] + "_dspec.npz"


### PR DESCRIPTION
…h the input time range

fix the issue in eovsa_flare_calib.py: when specifying a time range, ensure that it retrieves all IDB files necessary to cover the entire time range.
fix the issue in eovsa_flare_pipeline.py: if the provided end time is earlier than the start time of the ms file, adjust the end time to be the end time of the ms file.