### PR TITLE
typo fix and namespace more robust

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     casaviewer
     casaplotms
     PyQt5>=5.15.2
-    eosvapy
+    eovsapy
     aipy
 
 [options.extras_require]

--- a/suncasa/io/ndfits.py
+++ b/suncasa/io/ndfits.py
@@ -254,6 +254,11 @@ def read(filepath, hdus=None, verbose=False, **kwargs):
             meta['bmin'] = np.array(hdulist[-1].data['bmin'])
             meta['bpa'] = np.array(hdulist[-1].data['bpa'])
 
+        if hasattr(hdulist[-1].data, 'cbmaj'):
+            meta['bmaj'] = np.array(hdulist[-1].data['cbmaj'])
+            meta['bmin'] = np.array(hdulist[-1].data['cbmin'])
+            meta['bpa'] = np.array(hdulist[-1].data['cbpa'])
+
         else:
             if verbose:
                 print('FITS file does not have an additional frequency axis. '


### PR DESCRIPTION
I just found recent fits files still have beam keyword like "cbmaj", this pull request makes it compatible with both "bmaj" and "cbmaj"