### PR TITLE
Skip import of importeovsa and calibeovsa when dependencies are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+# Ignore Mac OS X .DS_Store files
+.DS_Store

--- a/suncasa/suncasatasks/__init__.py
+++ b/suncasa/suncasatasks/__init__.py
@@ -1,8 +1,28 @@
-__name__ = "suncasatasks"
-__all__ = ['ptclean6', 'subvs', 'importeovsa', 'calibeovsa', 'concateovsa']
-#
+# __init__.py of suncasa.suncasatasks
+import warnings
+
+# Always available modules
 from .ptclean6 import ptclean6
 from .subvs import subvs
-from .importeovsa import importeovsa
-from .calibeovsa import calibeovsa
 from .concateovsa import concateovsa
+
+__all__ = ['ptclean6', 'subvs', 'concateovsa']
+
+# Conditional import for modules that depend on 'aipy-eovsa'
+try:
+    from .importeovsa import importeovsa
+    __all__.append('importeovsa')
+except ImportError:
+    warnings.warn(
+        "Failed to import 'importeovsa'. This module requires 'eovsapy'. "
+        "Please install 'eovsapy' to use 'importeovsa'."
+    )
+
+try:
+    from .calibeovsa import calibeovsa
+    __all__.append('calibeovsa')
+except ImportError:
+    warnings.warn(
+        "Failed to import 'calibeovsa'. This module requires 'eovsapy'. "
+        "Please install 'eovsapy' to use 'calibeovsa'."
+    )

--- a/suncasa/suncasatasks/buildsuncasatasks.py
+++ b/suncasa/suncasatasks/buildsuncasatasks.py
@@ -6,8 +6,8 @@
 import os
 from glob import glob
 
-xmlfiles = glob('importeovsa*.xml')
-
+# xmlfiles = glob('calibeovsa*.xml')
+xmlfiles = ['calibeovsa.xml','importeovsa.xml']
 for xmlfile in xmlfiles:
     # os.system("buildmytasks --upgrade {}".format(xmlfile)) ## this only need to be run once.
     os.system("buildmytasks --module suncasatasks {}".format(xmlfile))

--- a/suncasa/suncasatasks/calibeovsa.py
+++ b/suncasa/suncasatasks/calibeovsa.py
@@ -5,9 +5,11 @@ import numpy
 from casatools.typecheck import CasaValidator as _val_ctor
 _pc = _val_ctor( )
 from casatools.coercetype import coerce as _coerce
+from casatools.errors import create_error_string
 from .private.task_calibeovsa import calibeovsa as _calibeovsa_t
 from casatasks.private.task_logging import start_log as _start_log
 from casatasks.private.task_logging import end_log as _end_log
+from casatasks.private.task_logging import except_log as _except_log
 
 class _calibeovsa:
     """
@@ -104,9 +106,17 @@ class _calibeovsa:
     def __call__( self, vis='', caltype=[  ], caltbdir='', interp='nearest', docalib=True, doflag=True, flagant='13~15', doimage=False, imagedir='.', antenna='0~12', timerange='', spw='1~3', stokes='XX', dosplit=False, outputvis='', doconcat=False, concatvis='', keep_orig_ms=True ):
         schema = {'vis': {'anyof': [{'type': 'cStr', 'coerce': _coerce.to_str}, {'type': 'cStrVec', 'coerce': [_coerce.to_list,_coerce.to_strvec]}]}, 'caltype': {'anyof': [{'type': 'cStr', 'coerce': _coerce.to_str}, {'type': 'cStrVec', 'coerce': [_coerce.to_list,_coerce.to_strvec]}]}, 'caltbdir': {'type': 'cStr', 'coerce': _coerce.to_str}, 'interp': {'type': 'cStr', 'coerce': _coerce.to_str}, 'docalib': {'type': 'cBool'}, 'doflag': {'type': 'cBool'}, 'flagant': {'type': 'cStr', 'coerce': _coerce.to_str}, 'doimage': {'type': 'cBool'}, 'imagedir': {'type': 'cStr', 'coerce': _coerce.to_str}, 'antenna': {'type': 'cStr', 'coerce': _coerce.to_str}, 'timerange': {'type': 'cStr', 'coerce': _coerce.to_str}, 'spw': {'type': 'cStr', 'coerce': _coerce.to_str}, 'stokes': {'type': 'cStr', 'coerce': _coerce.to_str}, 'dosplit': {'type': 'cBool'}, 'outputvis': {'anyof': [{'type': 'cStr', 'coerce': _coerce.to_str}, {'type': 'cStrVec', 'coerce': [_coerce.to_list,_coerce.to_strvec]}]}, 'doconcat': {'type': 'cBool'}, 'concatvis': {'type': 'cStr', 'coerce': _coerce.to_str}, 'keep_orig_ms': {'type': 'cBool'}}
         doc = {'vis': vis, 'caltype': caltype, 'caltbdir': caltbdir, 'interp': interp, 'docalib': docalib, 'doflag': doflag, 'flagant': flagant, 'doimage': doimage, 'imagedir': imagedir, 'antenna': antenna, 'timerange': timerange, 'spw': spw, 'stokes': stokes, 'dosplit': dosplit, 'outputvis': outputvis, 'doconcat': doconcat, 'concatvis': concatvis, 'keep_orig_ms': keep_orig_ms}
-        assert _pc.validate(doc,schema), str(_pc.errors)
+        assert _pc.validate(doc,schema), create_error_string(_pc.errors)
         _logging_state_ = _start_log( 'calibeovsa', [ 'vis=' + repr(_pc.document['vis']), 'caltype=' + repr(_pc.document['caltype']), 'caltbdir=' + repr(_pc.document['caltbdir']), 'interp=' + repr(_pc.document['interp']), 'docalib=' + repr(_pc.document['docalib']), 'doflag=' + repr(_pc.document['doflag']), 'flagant=' + repr(_pc.document['flagant']), 'doimage=' + repr(_pc.document['doimage']), 'imagedir=' + repr(_pc.document['imagedir']), 'antenna=' + repr(_pc.document['antenna']), 'timerange=' + repr(_pc.document['timerange']), 'spw=' + repr(_pc.document['spw']), 'stokes=' + repr(_pc.document['stokes']), 'dosplit=' + repr(_pc.document['dosplit']), 'outputvis=' + repr(_pc.document['outputvis']), 'doconcat=' + repr(_pc.document['doconcat']), 'concatvis=' + repr(_pc.document['concatvis']), 'keep_orig_ms=' + repr(_pc.document['keep_orig_ms']) ] )
-        return _end_log( _logging_state_, 'calibeovsa', _calibeovsa_t( _pc.document['vis'], _pc.document['caltype'], _pc.document['caltbdir'], _pc.document['interp'], _pc.document['docalib'], _pc.document['doflag'], _pc.document['flagant'], _pc.document['doimage'], _pc.document['imagedir'], _pc.document['antenna'], _pc.document['timerange'], _pc.document['spw'], _pc.document['stokes'], _pc.document['dosplit'], _pc.document['outputvis'], _pc.document['doconcat'], _pc.document['concatvis'], _pc.document['keep_orig_ms'] ) )
+        task_result = None
+        try:
+            task_result = _calibeovsa_t( _pc.document['vis'], _pc.document['caltype'], _pc.document['caltbdir'], _pc.document['interp'], _pc.document['docalib'], _pc.document['doflag'], _pc.document['flagant'], _pc.document['doimage'], _pc.document['imagedir'], _pc.document['antenna'], _pc.document['timerange'], _pc.document['spw'], _pc.document['stokes'], _pc.document['dosplit'], _pc.document['outputvis'], _pc.document['doconcat'], _pc.document['concatvis'], _pc.document['keep_orig_ms'] )
+        except Exception as exc:
+            _except_log('calibeovsa', exc)
+            raise
+        finally:
+            task_result = _end_log( _logging_state_, 'calibeovsa', task_result )
+        return task_result
 
 calibeovsa = _calibeovsa( )
 

--- a/suncasa/suncasatasks/gotasks/calibeovsa.py
+++ b/suncasa/suncasatasks/gotasks/calibeovsa.py
@@ -140,6 +140,9 @@ class _calibeovsa:
         output = [ ]
         addon = ''
         first_addon = True
+        if len(description) == 0:
+            out.write(param_prefix + " #\n")
+            return
         while len(description) > 0:
             ## starting a new line.....................................................................
             if len(output) == 0:
@@ -314,103 +317,193 @@ class _calibeovsa:
 
     #--------- subparam inp output ----------------------------------------------------
     def __vis_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__vis_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return ''
         description = ''
         value = self.__vis( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'vis': value},{'vis': self.__schema['vis']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'vis': value},{'vis': self.__schema['vis']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('%-15.15s = %s%-23s%s' % ('vis',pre,self.__to_string_(value),post),description,0+len(pre)+len(post))
     def __caltype_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__caltype_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return [  ]
         description = ''
         value = self.__caltype( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'caltype': value},{'caltype': self.__schema['caltype']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'caltype': value},{'caltype': self.__schema['caltype']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('%-15.15s = %s%-23s%s' % ('caltype',pre,self.__to_string_(value),post),description,0+len(pre)+len(post))
     def __caltbdir_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__caltbdir_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return ''
         description = ''
         value = self.__caltbdir( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'caltbdir': value},{'caltbdir': self.__schema['caltbdir']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'caltbdir': value},{'caltbdir': self.__schema['caltbdir']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('%-15.15s = %s%-23s%s' % ('caltbdir',pre,self.__to_string_(value),post),description,0+len(pre)+len(post))
     def __interp_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__interp_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return 'nearest'
         description = ''
         value = self.__interp( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'interp': value},{'interp': self.__schema['interp']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'interp': value},{'interp': self.__schema['interp']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('%-15.15s = %s%-23s%s' % ('interp',pre,self.__to_string_(value),post),description,0+len(pre)+len(post))
     def __docalib_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__docalib_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return True
         description = ''
         value = self.__docalib( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'docalib': value},{'docalib': self.__schema['docalib']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'docalib': value},{'docalib': self.__schema['docalib']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('%-15.15s = %s%-23s%s' % ('docalib',pre,self.__to_string_(value),post),description,0+len(pre)+len(post))
     def __doflag_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__doflag_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return True
         description = ''
         value = self.__doflag( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'doflag': value},{'doflag': self.__schema['doflag']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'doflag': value},{'doflag': self.__schema['doflag']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('\x1B[1m\x1B[47m%-15.15s =\x1B[0m %s%-23s%s' % ('doflag',pre,self.__to_string_(value),post),description,13+len(pre)+len(post))
     def __flagant_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__flagant_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return '13~15'
         if self.__flagant_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__flagant( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'flagant': value},{'flagant': self.__schema['flagant']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'flagant': value},{'flagant': self.__schema['flagant']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('flagant',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __doimage_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__doimage_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return False
         description = ''
         value = self.__doimage( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'doimage': value},{'doimage': self.__schema['doimage']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'doimage': value},{'doimage': self.__schema['doimage']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('\x1B[1m\x1B[47m%-15.15s =\x1B[0m %s%-23s%s' % ('doimage',pre,self.__to_string_(value),post),description,13+len(pre)+len(post))
     def __imagedir_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__imagedir_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return '.'
         if self.__imagedir_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__imagedir( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'imagedir': value},{'imagedir': self.__schema['imagedir']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'imagedir': value},{'imagedir': self.__schema['imagedir']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('imagedir',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __antenna_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__antenna_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return '0~12'
         if self.__antenna_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__antenna( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'antenna': value},{'antenna': self.__schema['antenna']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'antenna': value},{'antenna': self.__schema['antenna']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('antenna',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __timerange_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__timerange_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return ''
         if self.__timerange_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__timerange( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'timerange': value},{'timerange': self.__schema['timerange']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'timerange': value},{'timerange': self.__schema['timerange']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('timerange',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __spw_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__spw_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return '1~3'
         if self.__spw_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__spw( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'spw': value},{'spw': self.__schema['spw']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'spw': value},{'spw': self.__schema['spw']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('spw',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __stokes_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__stokes_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return 'XX'
         if self.__stokes_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__stokes( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'stokes': value},{'stokes': self.__schema['stokes']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'stokes': value},{'stokes': self.__schema['stokes']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('stokes',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __dosplit_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__dosplit_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return False
         description = ''
         value = self.__dosplit( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'dosplit': value},{'dosplit': self.__schema['dosplit']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'dosplit': value},{'dosplit': self.__schema['dosplit']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('\x1B[1m\x1B[47m%-15.15s =\x1B[0m %s%-23s%s' % ('dosplit',pre,self.__to_string_(value),post),description,13+len(pre)+len(post))
     def __outputvis_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__outputvis_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return ''
         if self.__outputvis_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__outputvis( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'outputvis': value},{'outputvis': self.__schema['outputvis']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'outputvis': value},{'outputvis': self.__schema['outputvis']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('outputvis',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __doconcat_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__doconcat_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return False
         description = ''
         value = self.__doconcat( self.__globals_( ) )
-        (pre,post) = ('','') if self.__validate_({'doconcat': value},{'doconcat': self.__schema['doconcat']}) else ('\x1B[91m','\x1B[0m')
+        (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'doconcat': value},{'doconcat': self.__schema['doconcat']}) else ('\x1B[91m','\x1B[0m')
         self.__do_inp_output('\x1B[1m\x1B[47m%-15.15s =\x1B[0m %s%-23s%s' % ('doconcat',pre,self.__to_string_(value),post),description,13+len(pre)+len(post))
     def __concatvis_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__concatvis_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return ''
         if self.__concatvis_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__concatvis( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'concatvis': value},{'concatvis': self.__schema['concatvis']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'concatvis': value},{'concatvis': self.__schema['concatvis']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('concatvis',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
     def __keep_orig_ms_inp(self):
+        def xml_default( ):
+            ## play the crazy subparameter shell game
+            dflt = self.__keep_orig_ms_dflt( self.__globals_( ) )
+            if dflt is not None: return dflt
+            return True
         if self.__keep_orig_ms_dflt( self.__globals_( ) ) is not None:
              description = ''
              value = self.__keep_orig_ms( self.__globals_( ) )
-             (pre,post) = ('','') if self.__validate_({'keep_orig_ms': value},{'keep_orig_ms': self.__schema['keep_orig_ms']}) else ('\x1B[91m','\x1B[0m')
+             (pre,post) = (('','') if value == xml_default( ) else ('\x1B[34m','\x1B[0m')) if self.__validate_({'keep_orig_ms': value},{'keep_orig_ms': self.__schema['keep_orig_ms']}) else ('\x1B[91m','\x1B[0m')
              self.__do_inp_output('   \x1B[92m%-12.12s =\x1B[0m %s%-23s%s' % ('keep_orig_ms',pre,self.__to_string_(value),post),description,9+len(pre)+len(post))
 
     #--------- global default implementation-------------------------------------------
@@ -463,25 +556,65 @@ class _calibeovsa:
 
     #--------- tget function ----------------------------------------------------------
     @static_var('state', __sf__('casa_inp_go_state'))
-    def tget(self,file=None):
+    def tget(self,savefile=None):
         from casashell.private.stack_manip import find_frame
         from runpy import run_path
-        filename = None
-        if file is None:
-            if os.path.isfile("calibeovsa.last"):
-                filename = "calibeovsa.last"
-        elif isinstance(file, str):
-            if os.path.isfile(file):
-                filename = file
-        if filename is not None:
+        filename = savefile
+        if filename is None:
+            filename = "calibeovsa.last" if os.path.isfile("calibeovsa.last") else "calibeovsa.saved"
+        if os.path.isfile(filename):
             glob = find_frame( )
             newglob = run_path( filename, init_globals={ } )
             for i in newglob:
                 glob[i] = newglob[i]
             self.tget.state['last'] = self
         else:
-            print("could not find last file, setting defaults instead...")
+            print("could not find last file: %s\nsetting defaults instead..." % filename)
             self.set_global_defaults( )
+
+    #--------- tput function ----------------------------------------------------------
+    def tput(self,outfile=None):
+        def noobj(s):
+           if s.startswith('<') and s.endswith('>'):
+               return "None"
+           else:
+               return s
+
+        _postfile = outfile if outfile is not None else os.path.realpath('calibeovsa.last')
+
+        _invocation_parameters = OrderedDict( )
+        _invocation_parameters['vis'] = self.__vis( self.__globals_( ) )
+        _invocation_parameters['caltype'] = self.__caltype( self.__globals_( ) )
+        _invocation_parameters['caltbdir'] = self.__caltbdir( self.__globals_( ) )
+        _invocation_parameters['interp'] = self.__interp( self.__globals_( ) )
+        _invocation_parameters['docalib'] = self.__docalib( self.__globals_( ) )
+        _invocation_parameters['doflag'] = self.__doflag( self.__globals_( ) )
+        _invocation_parameters['flagant'] = self.__flagant( self.__globals_( ) )
+        _invocation_parameters['doimage'] = self.__doimage( self.__globals_( ) )
+        _invocation_parameters['imagedir'] = self.__imagedir( self.__globals_( ) )
+        _invocation_parameters['antenna'] = self.__antenna( self.__globals_( ) )
+        _invocation_parameters['timerange'] = self.__timerange( self.__globals_( ) )
+        _invocation_parameters['spw'] = self.__spw( self.__globals_( ) )
+        _invocation_parameters['stokes'] = self.__stokes( self.__globals_( ) )
+        _invocation_parameters['dosplit'] = self.__dosplit( self.__globals_( ) )
+        _invocation_parameters['outputvis'] = self.__outputvis( self.__globals_( ) )
+        _invocation_parameters['doconcat'] = self.__doconcat( self.__globals_( ) )
+        _invocation_parameters['concatvis'] = self.__concatvis( self.__globals_( ) )
+        _invocation_parameters['keep_orig_ms'] = self.__keep_orig_ms( self.__globals_( ) )
+
+        try:
+            with open(_postfile,'w') as _f:
+                for _i in _invocation_parameters:
+                    _f.write("%-12s = %s\n" % (_i,noobj(repr(_invocation_parameters[_i]))))
+                _f.write("#calibeovsa( ")
+                count = 0
+                for _i in _invocation_parameters:
+                    _f.write("%s=%s" % (_i,noobj(repr(_invocation_parameters[_i]))))
+                    count += 1
+                    if count < len(_invocation_parameters): _f.write(",")
+                _f.write(" )\n")
+        except: return False
+        return True
 
     def __call__( self, vis=None, caltype=None, caltbdir=None, interp=None, docalib=None, doflag=None, flagant=None, doimage=None, imagedir=None, antenna=None, timerange=None, spw=None, stokes=None, dosplit=None, outputvis=None, doconcat=None, concatvis=None, keep_orig_ms=None ):
         def noobj(s):

--- a/suncasa/suncasatasks/private/task_calibeovsa.py
+++ b/suncasa/suncasatasks/private/task_calibeovsa.py
@@ -5,12 +5,20 @@ if platform.system() == 'Linux':
 import os
 import shutil
 import numpy as np
+def some_function_requiring_eovsapy(*args, **kwargs):
+    try:
+        import eovsapy
+    except ImportError:
+        raise ImportError("The 'eovsapy' package is required to use this function. Please install 'eovsapy' to proceed.")
+some_function_requiring_eovsapy()
+
 from eovsapy.util import extract as eoextract
 from eovsapy.util import Time
 from eovsapy import cal_header as ch
 from eovsapy import dbutil as db
 from eovsapy import pipeline_cal as pc
 from eovsapy.sqlutil import sql2refcalX, sql2phacalX
+
 
 try:
     from taskinit import casalog, tb, ms

--- a/suncasa/suncasatasks/private/task_calibeovsa.py
+++ b/suncasa/suncasatasks/private/task_calibeovsa.py
@@ -1,3 +1,22 @@
+def check_dependencies():
+    missing_packages = []
+    try:
+        import aipy
+    except ImportError:
+        missing_packages.append("aipy-eovsa")
+
+    try:
+        import eovsapy
+    except ImportError:
+        missing_packages.append("eovsapy")
+
+    if missing_packages:
+        raise ImportError(
+            "The following package(s) are required to use this function: {}. "
+            "Please install them to proceed.".format(", ".join(missing_packages))
+        )
+
+check_dependencies()
 import platform
 import matplotlib
 if platform.system() == 'Linux':
@@ -5,12 +24,6 @@ if platform.system() == 'Linux':
 import os
 import shutil
 import numpy as np
-def some_function_requiring_eovsapy(*args, **kwargs):
-    try:
-        import eovsapy
-    except ImportError:
-        raise ImportError("The 'eovsapy' package is required to use this function. Please install 'eovsapy' to proceed.")
-some_function_requiring_eovsapy()
 
 from eovsapy.util import extract as eoextract
 from eovsapy.util import Time

--- a/suncasa/suncasatasks/private/task_importeovsa.py
+++ b/suncasa/suncasatasks/private/task_importeovsa.py
@@ -1,5 +1,3 @@
-import sys
-
 def check_dependencies():
     missing_packages = []
     try:
@@ -19,6 +17,7 @@ def check_dependencies():
         )
 
 check_dependencies()
+import sys
 import os
 import numpy as np
 import numpy.ma as ma

--- a/suncasa/suncasatasks/private/task_importeovsa.py
+++ b/suncasa/suncasatasks/private/task_importeovsa.py
@@ -1,15 +1,34 @@
+import sys
+
+def check_dependencies():
+    missing_packages = []
+    try:
+        import aipy
+    except ImportError:
+        missing_packages.append("aipy-eovsa")
+
+    try:
+        import eovsapy
+    except ImportError:
+        missing_packages.append("eovsapy")
+
+    if missing_packages:
+        raise ImportError(
+            "The following package(s) are required to use this function: {}. "
+            "Please install them to proceed.".format(", ".join(missing_packages))
+        )
+
+check_dependencies()
 import os
 import numpy as np
 import numpy.ma as ma
 import scipy.constants as constants
 import time
-import aipy
-import sys
-from suncasa.eovsa import impteovsa as ipe
 from astropy.time import Time
 from eovsapy import util
 from eovsapy import dump_tsys as dtsys
-
+import aipy
+from suncasa.eovsa import impteovsa as ipe
 
 py3 = sys.version_info.major >= 3
 


### PR DESCRIPTION
Enhance suncasa.suncasatasks with conditional imports and actionable feedback

This PR enhances the `suncasa.suncasatasks` module by introducing conditional imports for `importeovsa` and `calibeovsa`, coupled with targeted warnings when `eovsapy` and `aipy-eovsa` dependencies are missing. This update not only prevents execution stoppage due to absent packages but also advises users on which specific packages to install should they require `importeovsa` or `calibeovsa` functionality. Addressing the issue highlighted in [Issue #270](https://github.com/suncasa/suncasa-src/issues/270), this improvement aims to bolster module usability, ensuring it remains operational and user-friendly, even when certain dependencies are absent.
