### PR TITLE
Update HelioviewerClient import to use hvpy if available

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     sunpy[all]
     PyQt5>=5.15.2
     h5py
+    hvpy
 
 [options.extras_require]
 eovsa=

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     extras_require=extras,
     # use_scm_version={'write_to': os.path.join('suncasa', '_version.py')},
     # version='0.1.2.9.1', ## test
-    version='1.0.5',  ## official
+    version='1.0.6',  ## official
     long_description=long_description,
     long_description_content_type='text/markdown'
     # ,

--- a/suncasa/eovsa/eovsa_flare_calib.py
+++ b/suncasa/eovsa/eovsa_flare_calib.py
@@ -90,8 +90,7 @@ def import_calib_idb(trange, workdir=None, ncpu=1, timebin='0s', width=1):
                                 doimage=False, doconcat=True,
                                 concatvis=concatvis, keep_orig_ms=False)
     outputvis = concatvis[:-3] + 'XXYY.ms'
-    split(vis=concatvis, outputvis=outputvis, correlation='XX,YY', datacolumn='data',
-          antenna='0~12&&0~12')
+    split(vis=concatvis, outputvis=outputvis, correlation='XX,YY', datacolumn='data')
                    
 
     return outputvis

--- a/suncasa/io/ndfits.py
+++ b/suncasa/io/ndfits.py
@@ -495,9 +495,15 @@ def wrap(fitsfiles, outfitsfile=None, docompress=False, mask=None, fix_invalid=T
 
             data = np.zeros((npol, nbd, ny, nx))
             cfreqs = []
+            cbmaj = []
+            cbmin = []
+            cbpa = []
             for sidx, fitsf in enumerate(fits_exist):
                 hdu = fits.open(fitsf)
                 cfreqs.append(hdu[-1].header['RESTFRQ'])
+                cbmaj.append(hdu[-1].header['BMAJ'])
+                cbmin.append(hdu[-1].header['BMIN'])
+                cbpa.append(hdu[-1].header['BPA'])
                 for pidx in range(npol):
                     if hdu[-1].data.ndim == 2:
                         data[pidx, idx_fits_exist[sidx], :, :] = hdu[-1].data
@@ -507,9 +513,15 @@ def wrap(fitsfiles, outfitsfile=None, docompress=False, mask=None, fix_invalid=T
                         data[pidx, idx_fits_exist[sidx], :, :] = hdu[-1].data[pidx, 0, :, :]
             cfreqs = np.array(cfreqs)
             cdelts = np.array(cdelts)
+            cbmaj = np.array(cbmaj)
+            cbmin = np.array(cbmin)
+            cbpa = np.array(cbpa)
             indfreq = np.argsort(cfreqs)
             cfreqs = cfreqs[indfreq]
             cdelts = cdelts[indfreq]
+            cbmaj = cbmaj[indfreq]
+            cbmin = cbmin[indfreq]
+            cbpa = cbpa[indfreq]
             for pidx in range(npol):
                 data[pidx, ...] = data[pidx, indfreq]
 

--- a/suncasa/utils/qlookplot.py
+++ b/suncasa/utils/qlookplot.py
@@ -2197,6 +2197,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
 
                 if nspws > 1:
                     imagefiles, fitsfiles = [], []
+
                     if restoringbeam == ['']:
                         if observatory == 'EOVSA':
                             restoringbms = mstools.get_bmsize(cfreqs, refbmsize=refbmsize, reffreq=reffreq, minbmsize=minbmsize)
@@ -2213,6 +2214,7 @@ def qlookplot(vis, timerange=None, spw='', spwplt=None,
                                   'and minimum beam size settings.')
                             restoringbms = mstools.get_bmsize(cfreqs, refbmsize=refbmsize, reffreq=reffreq,
                                                               minbmsize=minbmsize)
+                    print(f'restoringbms: {restoringbms}')
                     sto = stokes.replace(',', '')
                     print('Original phasecenter: ' + str(ra0) + str(dec0))
                     print('use phasecenter: ' + phasecenter)

--- a/suncasa/utils/qlookplot.py
+++ b/suncasa/utils/qlookplot.py
@@ -115,7 +115,8 @@ def read_imres(imresfile):
     for k, v in iterop_:
         imres[k] = list(np.array(v))
     Spw = sorted(list(set(imres['Spw'])))
-    Spw = [str(int(sp)) for sp in Spw]
+    # Spw = [str(int(sp)) for sp in Spw]
+    Spw = [str(int(sp)) if '~' not in sp else sp for sp in Spw]
     nspw = len(Spw)
     imres['Freq'] = [list(ll) for ll in imres['Freq']]
     Freq = sorted(uniq(imres['Freq']))
@@ -304,7 +305,10 @@ def get_colorbar_params(fbounds, stepfactor=1):
 
 
 def download_jp2(tstart, tend, wavelengths, outdir):
-    from sunpy.net.helioviewer import HelioviewerClient
+    try:
+        from hvpy import HelioviewerClient
+    except:
+        from sunpy.net.helioviewer import HelioviewerClient
     from astropy import time as time_module
     from sunpy import map as smap
     hv = HelioviewerClient()


### PR DESCRIPTION
- Attempt to import `HelioviewerClient` from `hvpy` first.
- Fallback to importing `HelioviewerClient` from `sunpy.net.helioviewer` if `hvpy` is not available.
- This change is due to the deprecation of `sunpy.net.helioviewer`.