### PR TITLE
Major updates to helioimage2fits to use coordinates as JPL Horizons query input

### DIFF
--- a/suncasa/utils/helioimage2fits.py
+++ b/suncasa/utils/helioimage2fits.py
@@ -86,7 +86,31 @@ def ms_restorehistory(msfile):
     os.system('mv {0}_bk {0}'.format(tb_history))
 
 
-def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False, use_astropy=True):
+def observatory_to_coord(observatory):
+    """
+    Function to convert observatory name or id to coordinates used by JPL Horizons
+    Coordinate system is specified as 'geodetic longitude (deg), geodetic latitude (deg), altitude above reference ellipsoid (km)' 
+    See https://ssd.jpl.nasa.gov/horizons/manual.html#center for detailed documentation
+    """
+    observatory = observatory.upper()
+    if observatory == 'EVLA' or observatory == 'VLA' or observatory=='-5':
+        site_coord = '252.382,34.0788132,2.11447'
+    elif observatory == 'EOVSA' or observatory == 'FASR':
+        site_coord = '241.713,37.2332,1.20713'
+    elif observatory == 'OVRO_MMA' or observatory == "OVRO-LWA" or observatory == 'OVRO':
+        site_coord = '241.718406,37.240115,1.18835'
+    elif observatory == 'ALMA' or observatory == '-7':
+        site_coord = '292.2452521,-23.029211,5.07489'
+    elif observatory == 'GMRT' or observatory == 'uGMRT':
+        site_coord = '74.050508,19.093096,.60663'
+    elif observatory == 'geocentric' or observatory == '500':
+        site_coord = '0.0,0.0,-6378.137'
+    else:
+        print('Observatory {} not recognized. Assume OVRO.'.format(observatory))
+        site_coord = '241.718406,37.240115,1.18835'
+    return site_coord
+
+def read_horizons(t0=None, dur=None, vis=None, observatory=None, verbose=False, use_astropy=False):
     """
     This function visits JPL Horizons to retrieve J2000 topocentric RA and DEC of the solar disk center
     as a function of time.
@@ -99,30 +123,54 @@ def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False
     observatory: observatory code (from JPL Horizons). If not provided, use information from visibility.
          if no visibility found, use earth center (code=500)
     verbose: True to provide extra information
+    use_astropy: whether or not to use astropy to obtain the empheris
 
     Usage:
     >>> from astropy.time import Time
     >>> out = read_horizons(t0=Time('2017-09-10 16:00:00'), observatory='-81')
     >>> out = read_horizons(vis = 'mydata.ms')
-
-    History:
-    BC (sometime in 2014): function was first wrote, followed by a number of edits by BC and SY
-    BC (2019-07-16): Added docstring documentation
-
-    '''
     
-=======
     """
+    from astropy.time import Time
 
-    # uppercase the observatory name
-    observatory = observatory.upper()
+    if vis:
+        if not os.path.exists(vis):
+            print('Input ms data ' + vis + ' does not exist! ')
+            return -1
+        try:
+            ms.open(vis)
+            metadata = ms.metadata()
+            observatory_meta = metadata.observatorynames()[0]
+            metadata.close()
+            if verbose:
+                print('The observatory is {} in this visibility file'.format(observatory_meta))
+            if observatory is None:
+                observatory = observatory_meta
+            ms.close()
+
+            tb.open(vis)
+            btime_vis = Time(tb.getcell('TIME', 0) / 24. / 3600., format='mjd')
+            etime_vis = Time(tb.getcell('TIME', tb.nrows() - 1) / 24. / 3600., format='mjd')
+            tb.close()
+            if verbose:
+                print("Beginning time of this scan " + btime_vis.iso)
+                print("End time of this scan " + etime_vis.iso)
+
+            # extend the start and end time for jpl horizons by 0.5 hr on each end
+            btime = Time(btime_vis.mjd - 0.5 / 24., format='mjd')
+            dur = etime_vis.mjd - btime_vis.mjd + 1.0 / 24.
+        except Exception as error:
+            print(error)
+            print('error in reading ms file: ' + vis + ' to obtain the ephemeris!')
+            return -1
 
     if use_astropy:
-
         from sunpy.coordinates import sun
-        from astropy.time import Time
         from astropy import units as u
         from astropy.coordinates import get_body, EarthLocation
+
+        if observatory is None:
+            observatory = 'OVRO'
 
         if not t0 and not vis:
             t0 = Time.now()
@@ -131,9 +179,9 @@ def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False
         if t0:
             try:
                 btime = Time(t0)
-                
-            except:
+            except Exception as error:
                 print('input time ' + str(t0) + ' not recognized')
+                print(error)
                 return -1
 
         JPL_AU = 149597870700.0  # meters
@@ -172,7 +220,6 @@ def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False
 
         ephem = {'time': time_set, 'ra': ra_set, 'dec': dec_set, 'p0': p0_set, 'delta': delta_set} 
 
-
     else:
         if not t0 and not vis:
             t0 = Time.now()
@@ -181,80 +228,30 @@ def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False
         if t0:
             try:
                 btime = Time(t0)
-                
-            except:
+            except Exception as error:
                 print('input time ' + str(t0) + ' not recognized')
+                print(error)
                 return -1
 
-        if observatory:
+        if observatory is None:
+            site_coord = observatory_to_coord('OVRO')
+        else:
             # If "observatory" is provided, it takes precedence
-            # turn observatory names into JPL Horizons' codes
-            if observatory == 'EVLA' or observatory == '-5' or observatory=='VLA':
-                observatory = '-5'
-            elif observatory == 'EOVSA' or observatory == 'FASR' or observatory == 'OVRO_MMA' or observatory == "OVRO" or observatory == '-81':
-                observatory = '-81'
-            elif observatory == 'ALMA' or observatory == '-7':
-                observatory = '-7'
-            elif observatory == 'GMRT' or observatory == 'uGMRT' or observatory == '399':
-                observatory = '399'
-            elif observatory == 'geocentric' or observatory == '500':
-                observatory = '500'
-            else:
-                print('Observatory {} not recognized. Assume geocentric.'.format(observatory))
-                observatory = '500'
-
-        if vis:
-            if not os.path.exists(vis):
-                print('Input ms data ' + vis + ' does not exist! ')
-                return -1
-            try:
-                if not observatory:
-                    ms.open(vis)
-                    metadata = ms.metadata()
-                    if metadata.observatorynames()[0] == 'EVLA':
-                        observatory = '-5'
-                    elif metadata.observatorynames()[0] == 'EOVSA' or metadata.observatorynames()[0] == 'FASR' or metadata.observatorynames()[0] == 'OVRO_MMA':
-                        observatory = '-81'
-                    elif metadata.observatorynames()[0] == 'GMRT' or metadata.observatorynames()[0] == 'uGMRT':
-                        observatory = '399'
-                    elif metadata.observatorynames()[0] == 'ALMA':
-                        observatory = '-7'
-                    else:
-                        print('Observatory {} not recognized. Assume geocentric.'.format(metadata.observatorynames()[0]))
-                        observatory = '500'
-                    metadata.close()
-                    ms.close()
-
-                tb.open(vis)
-                btime_vis = Time(tb.getcell('TIME', 0) / 24. / 3600., format='mjd')
-                etime_vis = Time(tb.getcell('TIME', tb.nrows() - 1) / 24. / 3600., format='mjd')
-                tb.close()
-                if verbose:
-                    print("Beginning time of this scan " + btime_vis.iso)
-                    print("End time of this scan " + etime_vis.iso)
-
-                # extend the start and end time for jpl horizons by 0.5 hr on each end
-                btime = Time(btime_vis.mjd - 0.5 / 24., format='mjd')
-                dur = etime_vis.mjd - btime_vis.mjd + 1.0 / 24.
-            except:
-                print('error in reading ms file: ' + vis + ' to obtain the ephemeris!')
-                return -1
-
-        # Neither observatory is defined or found through provided visibility. Assume geocentric.
-        if not observatory:
-            observatory = '500'
+            if verbose:
+                print('Using observatory {} to generate emphemeris'.format(observatory))
+            site_coord = observatory_to_coord(observatory)
 
         # default the observatory to geocentric, if none provided
         etime = Time(btime.mjd + dur, format='mjd')
         
         try:
-            cmdstr = "https://ssd.jpl.nasa.gov/api/horizons.api?format=text&TABLE_TYPE='OBSERVER'&QUANTITIES='1,17,20'&CSV_FORMAT='YES'&ANG_FORMAT='DEG'&CAL_FORMAT='BOTH'&SOLAR_ELONG='0,180'&CENTER='{}@399'&COMMAND='sun'&START_TIME='".format(
-                observatory) + btime.iso.replace(' ', ',') + "'&STOP_TIME='" + etime.iso[:-4].replace(' ',
+            cmdstr = "https://ssd.jpl.nasa.gov/api/horizons.api?format=text&TABLE_TYPE='OBSERVER'&QUANTITIES='1,17,20'&CSV_FORMAT='YES'&ANG_FORMAT='DEG'&CAL_FORMAT='BOTH'&SOLAR_ELONG='0,180'&CENTER='coord@399'&COORD_TYPE='GEODETIC'&SITE_COORD='{}'&COMMAND='sun'&START_TIME='".format(
+                site_coord) + btime.iso.replace(' ', ',') + "'&STOP_TIME='" + etime.iso[:-4].replace(' ',
                                                                                                     ',') + "'&STEP_SIZE='1m'&SKIP_DAYLT='NO'&EXTRA_PREC='YES'&APPARENT='REFRACTED'"
-            # cmdstr = "https://ssd.jpl.nasa.gov/horizons_batch.cgi?batch=1&TABLE_TYPE='OBSERVER'&QUANTITIES='1,17,20'&CSV_FORMAT='YES'&ANG_FORMAT='DEG'&CAL_FORMAT='BOTH'&SOLAR_ELONG='0,180'&CENTER='{}@399'&COMMAND='10'&START_TIME='".format(
-            #     observatory) + btime.iso.replace(' ', ',') + "'&STOP_TIME='" + etime.iso[:-4].replace(' ',
-            #                                                                                           ',') + "'&STEP_SIZE='1m'&SKIP_DAYLT='NO'&EXTRA_PREC='YES'&APPARENT='REFRACTED'"
             cmdstr = cmdstr.replace("'", "%27")
+            if verbose:
+                print('Query Horizons using the following url')
+                print(cmdstr)
             # print('1################')
             
             try:
@@ -264,41 +261,21 @@ def read_horizons(t0=None, dur=None, vis=None, observatory="OVRO", verbose=False
                 f = urlopen(cmdstr)
             lines = f.readlines()
             f.close()
-        except:
+        except Exception as error:
             # todo use geocentric coordinate for the new VLA data
-            print ("here")
+            print(error)
+            print ("Use an alternative method to query")
             import requests, collections
             params = collections.OrderedDict()
-            # params['batch'] = '1'
-            # params['TABLE_TYPE'] = "'OBSERVER'"
-            # params['QUANTITIES'] = "'1,17,20'"
-            # params['CSV_FORMAT'] = "'YES'"
-            # params['ANG_FORMAT'] = "'DEG'"
-            # params['CAL_FORMAT'] = "'BOTH'"
-            # params['SOLAR_ELONG'] = "'0,180'"
-            # if observatory == '500':
-            #     params['CENTER'] = "'500'"
-            # else:
-            #     params['CENTER'] = "'{}@399'".format(observatory)
-            # params['COMMAND'] = "'10'"
-            # params['START_TIME'] = "'{}'".format(btime.iso[:-4].replace(' ', ','))
-            # params['STOP_TIME'] = "'{}'".format(etime.iso[:-4].replace(' ', ','))
-            # params['STEP_SIZE'] = "'1m'"
-            # params['SKIP_DAYLT'] = "'NO'"
-            # params['EXTRA_PREC'] = "'YES'"
-            # params['APPAENT'] = "'REFRACTED'"
-            # results = requests.get("https://ssd.jpl.nasa.gov/horizons_batch.cgi", params=params)
-
             params['EPHEM_TYPE'] = "'OBSERVER'"
             params['QUANTITIES'] = "'1,17,20'"
             params['CSV_FORMAT'] = "'YES'"
             params['ANG_FORMAT'] = "'DEG'"
             params['CAL_FORMAT'] = "'BOTH'"
             params['SOLAR_ELONG'] = "'0,180'"
-            if observatory == '500':
-                params['CENTER'] = "'500'"
-            else:
-                params['CENTER'] = "'{}@399'".format(observatory)
+            params['CENTER'] = "coord@399"
+            params['COORD_TYPE'] = "GEODETIC"
+            params['SITE_COORD'] = "'{}'".format(site_coord)
             params['COMMAND'] = "'sun'"
             params['START_TIME'] = "'{}'".format(btime.iso[:-4].replace(' ', ','))
             params['STOP_TIME'] = "'{}'".format(etime.iso[:-4].replace(' ', ','))
@@ -718,25 +695,8 @@ def ephem_to_helio(vis=None, ephem=None, msinfo=None, reftime=None, dopolyfit=Tr
         # compare with ephemeris from JPL Horizons
         if not usephacenter:
             # Do not need to read the information from the measurement set
-            if msinfo0['observatory'] == 'EVLA':
-                observatory_id = '-5'
-                observatory = 'vla'
-            elif msinfo0['observatory'] == 'EOVSA' or msinfo0['observatory'] == 'FASR' or msinfo0['observatory'] == 'OVRO_MMA':
-                observatory_id = '-81'
-                observatory = 'ovro'
-            elif msinfo0['observatory'] == 'GMRT' or msinfo0['observatory'] == 'uGMRT':
-                observatory_id = '399'
-                observatory = 'gmrt'
-            elif msinfo0['observatory'] == 'ALMA':
-                observatory_id = '-7'
-                observatory = 'alma'
-            else:
-                print('Observatory {} not recognized. Assume OVRO.'.format(msinfo0['observatory']))
-                observatory_id = '500'
-                observatory = 'ovro'
-
             if not ephem:
-                ephem = read_horizons(Time(tref_d, format='mjd'), observatory=observatory)
+                ephem = read_horizons(Time(tref_d, format='mjd'), observatory=msinfo0['observatory'])
 
         times_ephem = ephem['time']
         ras_ephem = ephem['ra']
@@ -1319,16 +1279,7 @@ def calc_phasecenter_from_solxy(vis, timerange='', xycen=None, usemsphacenter=Tr
     '''
     ms.open(vis)
     metadata = ms.metadata()
-    if not observatory:
-        observatory = metadata.observatorynames()[0]
-        if metadata.observatorynames()[0] == 'EVLA':
-            observatory = '-5'
-        elif metadata.observatorynames()[0] == 'EOVSA' or metadata.observatorynames()[0] == 'FASR' or metadata.observatorynames()[0] == 'OVRO_MMA':
-            observatory = '-81'
-        elif metadata.observatorynames()[0] == 'GMRT' or metadata.observatorynames()[0] == 'uGMRT':
-            observatory_id = '399'
-        elif metadata.observatorynames()[0] == 'ALMA':
-            observatory = '-7'
+    observatory = metadata.observatorynames()[0]
        
     try:
         mstrange = metadata.timerangeforobs(0)


### PR DESCRIPTION
- Fixed a bug of failure when vis is provided but use_astropy is set to True.
- Change the default JPL Horizons query from using observatory id to actual coordinates. This avoids change of observatory id mapping to different places (e.g., -81 used to point to OVRO, now some other telescope in Germany).
- Added function observatory_to_coord() to convert observatory name or id to coordinates (long, lat, altitude)
- Set the default of use_astropy to False in read_horizons(). It makes more sense as this function is called read_horizons... @peijin94 you may want to add "use_astropy=True" in all read_horizons calls in the OVRO-LWA software if you wish to maximize performance.