### PR TITLE
Support dynamic FITS table column mapping in read()

### DIFF
--- a/suncasa/dspec/dspec.py
+++ b/suncasa/dspec/dspec.py
@@ -325,7 +325,8 @@ class Dspec:
                 self.telescope = ''
                 self.observatory = ''
 
-            if source.lower() == 'lwa' and fname.endswith('.fits'):
+            if source.lower() == 'lwa':
+                if fname.endswith('.fits'):
                     hdu = fits.open(fname) 
                     self.data = hdu[0].data
                     tim = hdu[2].data
@@ -333,6 +334,19 @@ class Dspec:
                     self.time_axis = Time(tmjd, format='mjd')
                     self.freq_axis = hdu[1].data['sfreq'] * 1e9
                     self.pol = [hdu[0].header['POLARIZA']]
+                    self.spec_unit = 'sfu'
+                    self.telescope = 'LWA'
+                    self.observatory = 'OVRO'
+                else:
+                    from .sources import lwa
+                    spec, tim, freq, pol, calfac_x, calfac_y, bkg_flux = lwa.read_data(fname, **kwargs)
+                    self.data = spec
+                    self.time_axis = Time(tim, format='mjd')
+                    self.freq_axis = freq
+                    self.pol = pol
+                    self.calfac_x = calfac_x # correction factor for X pol, same shape as freq
+                    self.calfac_y = calfac_y # correction factor for Y pol, same shape as freq
+                    self.bkg_flux = bkg_flux
                     self.spec_unit = 'sfu'
                     self.telescope = 'LWA'
                     self.observatory = 'OVRO'

--- a/suncasa/dspec/dspec.py
+++ b/suncasa/dspec/dspec.py
@@ -313,6 +313,7 @@ class Dspec:
                     self.telescope = 'EOVSA'
                     self.observatory = 'OVRO'
 
+
             if source.lower() == 'suncasa':
                 spec, tim, freq, bl, pol, spec_unit = self.rd_dspec(fname, spectype='amp', spec_unit='jy')
                 self.data = spec
@@ -336,7 +337,7 @@ class Dspec:
                     self.telescope = 'LWA'
                     self.observatory = 'OVRO'
 
-            if source.lower() =='general' and (fname.endswith('.fits') or fname.endswith('.fts')):
+            if source.lower() =='general' and (fname.endswith('.fits') or fname.endswith('.fts') or fname.endswith('.fit')):
                 hdu = fits.open(fname)
                 self.data = hdu[0].data
                 tim = hdu[2].data
@@ -364,7 +365,15 @@ class Dspec:
             self.spec_unit = 'sfu'
             self.telescope = 'LWA'
             self.observatory = 'OVRO'
-
+        elif source.lower()=='ecallisto':
+            from .sources import ecallisto
+            s = ecallisto.get_dspec(fname, doplot=False)
+            self.data = s['spectrogram']
+            self.time_axis = Time(s['time_axis'], format='mjd')
+            self.freq_axis = s['spectrum_axis'] * 1e6
+            self.spec_unit = 'sfu'
+            self.telescope = 'e-callisto'
+            self.observatory = 'e-callisto'
         else:
             raise ValueError(f"Unsupported data source or type provided: {source}")
 

--- a/suncasa/dspec/sources/ecallisto.py
+++ b/suncasa/dspec/sources/ecallisto.py
@@ -1,0 +1,110 @@
+from astropy.io import fits
+from astropy.time import Time
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+from matplotlib.dates import DateFormatter
+import numpy as np
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+def get_dspec(filenames, doplot=False, vmax=None, vmin=None, norm=None, cmap='viridis'):
+    """
+    Read one or more e-Callisto spectrogram FITS files and return a combined spectrogram dictionary.
+    Optionally display a quicklook plot.
+
+    Parameters
+    ----------
+    filenames : str or list of str
+        Path(s) to e-Callisto FITS file(s).
+    doplot : bool
+        Whether to plot the dynamic spectrum.
+    vmax, vmin : float
+        Color scale limits.
+    norm : matplotlib.colors.Normalize
+        Custom normalization for the color scale.
+    cmap : str or colormap
+        Colormap name or object.
+
+    Returns
+    -------
+    dict
+        {
+            'spectrogram': 2D array [nfreq, total_ntimes],
+            'spectrum_axis': 1D array of frequencies [MHz],
+            'time_axis': 1D array of MJD values
+        }
+    """
+    if isinstance(filenames, str):
+        filenames = [filenames]
+
+    all_specs = []
+    all_times = []
+    freqs = None
+
+    for i, filename in enumerate(filenames):
+        hdulist = fits.open(filename)
+        spec = hdulist[0].data  # shape: (nfreq, ntimes)
+        header = hdulist[0].header
+        info = hdulist[1].data[0]
+
+        time_sec = np.array(info['TIME'])  # seconds of the day
+        freqs_file = np.array(info['FREQUENCY'])  # in MHz
+
+        # Convert to MJD using DATE-OBS + TIME-OBS in header
+        date_obs_str = header.get('DATE-OBS', '').replace('/', '-') + 'T' + header.get('TIME-OBS', '00:00:00.000')
+        t0 = Time(date_obs_str, format='isot', scale='utc')
+        tmjd = t0.mjd + time_sec / 86400.0
+
+        if i == 0:
+            freqs = freqs_file
+        else:
+            if not np.allclose(freqs_file, freqs, atol=1e-3):
+                print(f"Warning: frequency axis mismatch in file {filename}")
+
+        all_specs.append(spec)
+        all_times.append(tmjd)
+        hdulist.close()
+
+    # Concatenate along time axis
+    spec_combined = np.concatenate(all_specs, axis=1)  # concatenate time axis
+    time_combined = np.concatenate(all_times)
+
+    # Optional plot
+    if doplot:
+        tim = Time(time_combined, format='mjd')
+        timplt = tim.plot_date
+        ntim = len(timplt)
+        nfreq = len(freqs)
+
+        fig, ax = plt.subplots(figsize=(9, 4))
+        pcm = ax.pcolormesh(timplt, freqs, spec_combined, shading='auto', cmap=cmap,
+                            norm=norm, vmax=vmax, vmin=vmin, rasterized=True)
+        ax.set_title("e-Callisto Dynamic Spectrum")
+        ax.set_xlabel("Time [UT]")
+        ax.set_ylabel("Frequency [MHz]")
+        ax.xaxis.set_major_formatter(DateFormatter("%H:%M"))
+        ax.set_ylim(freqs[0], freqs[-1])
+        ax.set_xlim(tim[0].plot_date, tim[-1].plot_date)
+        ax.set_facecolor(pcm.get_cmap()(0.0))
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="2%", pad=0.05)
+        plt.colorbar(pcm, cax=cax, label="Intensity [arb. units]")
+
+        def format_coord(x, y):
+            col = np.argmin(np.abs(timplt - x))
+            row = np.argmin(np.abs(freqs - y))
+            if 0 <= col < ntim and 0 <= row < nfreq:
+                timstr = tim[col].isot
+                flux = spec_combined[row, col]
+                return f'time: {timstr}, freq: {y:.1f} MHz, intensity: {flux:.2f}'
+            else:
+                return f'x = {x:.3f}, y = {y:.1f}'
+
+        ax.format_coord = format_coord
+        fig.tight_layout()
+        plt.show()
+
+    return {
+        'spectrogram': spec_combined,
+        'spectrum_axis': freqs,
+        'time_axis': time_combined
+    }

--- a/suncasa/utils/ovsas_spectrogram.py
+++ b/suncasa/utils/ovsas_spectrogram.py
@@ -57,7 +57,7 @@ def setup_time_axis(ax, start, end, minticks=5, maxticks=10):
 
 
 def plot(timestamp=None, timerange=None, figdir='/common/lwa/spec_v2/daily/', figname=None, combine=True,
-         clip=[10, 99.995], add_logo=False, fast_plot=True, interactive=False):
+         clip=[10, 99.995], add_logo=False, fast_plot=True, interactive=False, overwrite=False):
     """
     Plot the OVRO-LWA and EOVSA spectrograms along with STIX and GOES light curves for a given timestamp or time range.
 
@@ -155,9 +155,10 @@ def plot(timestamp=None, timerange=None, figdir='/common/lwa/spec_v2/daily/', fi
             # Define the file name for the combined figure
             figname = os.path.join(figdir, f'fig-OVSAs_spec_{timestamp.strftime("%Y%m%d")}.jpg')
         if os.path.exists(figname):
-            if timerange is None:
-                # If the combined figure already exists, skip plotting individual figures
-                print(f'Combined figure for {timestamp.strftime("%Y-%m-%d")} already exists. Skipping individual figures.')
+            if overwrite:
+                os.system(f'rm -f {figname}')
+            else:
+                print(f'Combined figure for {timestamp.strftime("%Y-%m-%d")} already exists. Skipping.')
                 return [figname]
     else:
         # Define file names for each figure
@@ -210,7 +211,10 @@ def plot(timestamp=None, timerange=None, figdir='/common/lwa/spec_v2/daily/', fi
         ax_ovrolwa.text(0.5, 0.5, 'No OVRO-LWA data available', transform=ax_ovrolwa.transAxes,
                         ha='center', va='center', fontsize=12, color='gray')
         ax_ovrolwa.set_ylabel('Frequency [MHz]')
-        ax_ovrolwa.set_ylim(29.033934, 83.871824)
+        if timestamp>= datetime(2025, 4, 18):
+            ax_ovrolwa.set_ylim(15, 85)
+        else:
+            ax_ovrolwa.set_ylim(29.033934, 83.871824)
         ovro_lwa_start, ovro_lwa_end = default_start_time, default_end_time
         divider = make_axes_locatable(ax_ovrolwa)
         cax_spec = divider.append_axes('right', size='1.5%', pad=0.05)


### PR DESCRIPTION
Support dynamic FITS table column mapping in read()

Use a concise key_map for known table fields (`cfreqs`, `cdelts`, `cbmaj`, `cbmin`, `cbpa`) to map them to the appropriate meta keys (`ref_cfreqs`, `ref_freqdelts`, `bmaj`, `bmin`, `bpa`). All other columns in the last HDU are now automatically included under their original names, eliminating the need to update code whenever new FITS table columns are added.

Refs https://github.com/suncasa/suncasa-src/issues/311