### PR TITLE
Making lwa spectrum process more robust 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.6,!=3.7.*,<3.11
+python_requires = >=3.6,!=3.7.*
 packages = find:
 include_package_data = True
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ setup_requires =
     setuptools_scm
 install_requires =
     sunpy[all]
-    PyQt5>=5.15.2
     h5py
     hvpy
 

--- a/suncasa/dspec/sources/lwa.py
+++ b/suncasa/dspec/sources/lwa.py
@@ -75,16 +75,17 @@ def read_data(filename, stokes='I', timerange=[], freqrange=[], timebin=1, freqb
             print('Processing {0:d} of {1:d} files'.format(n+1, len(filelist)))
         try:
             data = h5py.File(file, 'r',swmr=True)
+            freqs = data['Observation1']['Tuning1']['freq'][:]
+            ts = data['Observation1']['time'][:]
+            # The following line works the same way as timestamp_to_mjd(), but a bit too slow
+            # times_mjd = np.array([(Time(t[0], format='unix') + TimeDelta(t[1], format='sec')).mjd for t in ts])
+            times_mjd = timestamp_to_mjd(ts)
+            idx0, = np.where(times_mjd > 50000.) # filter out those prior to 1995 (obviously wrong for OVRO-LWA)
+
         except:
             print('Cannot read {0:s}. Skip this file.'.format(file))
             continue
-        freqs = data['Observation1']['Tuning1']['freq'][:]
-        ts = data['Observation1']['time'][:]
-        # The following line works the same way as timestamp_to_mjd(), but a bit too slow
-        # times_mjd = np.array([(Time(t[0], format='unix') + TimeDelta(t[1], format='sec')).mjd for t in ts])
-        times_mjd = timestamp_to_mjd(ts)
-        idx0, = np.where(times_mjd > 50000.) # filter out those prior to 1995 (obviously wrong for OVRO-LWA)
-
+        
         # read the flux factors file if provided
         if not (flux_factor_file is None): 
             try:


### PR DESCRIPTION
The previous way will get stuck on corrupted h5 files.

Now including array loading in try-except.